### PR TITLE
getBaseUrl() creates an invalid URL, using the routing instead.

### DIFF
--- a/src/Anouar/Paypalpayment/PaypalPayment.php
+++ b/src/Anouar/Paypalpayment/PaypalPayment.php
@@ -178,18 +178,7 @@ class PaypalPayment{
 	 */
 	public static function getBaseUrl() {
 
-		$protocol = 'http';
-		if ($_SERVER['SERVER_PORT'] == 443 || (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on')) {
-			$protocol .= 's';
-			$protocol_port = $_SERVER['SERVER_PORT'];
-		} else {
-			$protocol_port = 80;
-		}
-
-		$host = $_SERVER['HTTP_HOST'];
-		$port = $_SERVER['SERVER_PORT'];
-		$request = $_SERVER['PHP_SELF'];
-		return dirname($protocol . '://' . $host . ($port == $protocol_port ? '' : ':' . $port) . $request);
+		return URL:to('/');
 	}
 
 	//grape payment details using the paymentId


### PR DESCRIPTION
I did this because by trying to use getBaseUrl() I got something like this: `http://localhost:8000:8000/index.php/payment/ExecutePayment?success=true`
