### PR TITLE
Update for laravel 4.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x",
+        "illuminate/support": "4.2.x",
         "php": ">=5.3.0",
         "ext-curl": "*",
         "ext-json": "*",


### PR DESCRIPTION
Please apply this patch so that users using 4.2.\* can install. Currently it gives error when trying to install on 4.2.*
