### PR TITLE
Fix .ini "#" comments deprecation

### DIFF
--- a/src/Anouar/Paypalpayment/sdk_config.ini
+++ b/src/Anouar/Paypalpayment/sdk_config.ini
@@ -14,7 +14,7 @@ http.Retry = 1
 ;Service Configuration
 [Service]
 service.EndPoint="https://api.sandbox.paypal.com"
-; Uncomment this line for integrating with the live endpoint 
+; Uncomment this line for integrating with the live endpoint
 ; service.EndPoint="https://api.paypal.com"
 
 
@@ -23,13 +23,13 @@ service.EndPoint="https://api.sandbox.paypal.com"
 
 log.LogEnabled=true
 
-# When using a relative path, the log file is created
-# relative to the .php file that is the entry point
-# for this request. You can also provide an absolute
-# path here
+;When using a relative path, the log file is created
+;relative to the .php file that is the entry point
+;for this request. You can also provide an absolute
+;path here
 log.FileName=../PayPal.log
 
-# Logging level can be one of FINE, INFO, WARN or ERROR
-# Logging is most verbose in the 'FINE' level and
-# decreases as you proceed towards ERROR
+;Logging level can be one of FINE, INFO, WARN or ERROR
+;Logging is most verbose in the 'FINE' level and
+;decreases as you proceed towards ERROR
 log.LogLevel=FINE


### PR DESCRIPTION
Fix this error.

```
Comments starting with '#' are deprecated in ....\vendor\anouar\paypalpayment\src\Anouar\Paypalpayment/sdk_config.ini on line 26
```
