### PR TITLE
Change from composer require-dev to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 Install this package through Composer. To your `composer.json` file, add:
 
 ```js
-"require-dev": {
+"require": {
     "anouar/paypalpayment": "dev-master"
 }
 ```


### PR DESCRIPTION
Users will end up with the package not being installed via composer install on their production environment if added to composer.json under require-dev. (They shouldn't be doing composer install --dev on production environments)
