### PR TITLE
Change composer.json required package version from dev-master to 1.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install this package through Composer. To your `composer.json` file, add:
 
 ```js
 "require": {
-    "anouar/paypalpayment": "dev-master"
+    "anouar/paypalpayment": "1.*"
 }
 ```
 


### PR DESCRIPTION
This allows people with composer.json setting "minimum-stability" set to stable to install the package.
