### PR TITLE
Update composer.json for Laravel 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~4.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "paypal/rest-api-sdk-php": "v0.13.2"
+        "paypal/rest-api-sdk-php": "1.3.2"
     },
     "require-dev":{
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Upgrade paypal sdk version to prevent *Method PayPal\Api\Sale::getTransactionFee() does not exist* error. See more https://github.com/xroot/laravel-paypalpayment/issues/52 and https://github.com/paypal/PayPal-PHP-SDK/issues/255